### PR TITLE
fix: add missing link for introduction on compile page of tutorial

### DIFF
--- a/docs/tutorials/bitcoin-price-feed/aggregations.md
+++ b/docs/tutorials/bitcoin-price-feed/aggregations.md
@@ -1,9 +1,9 @@
 # 3. Define the aggregator and tally functions
 
-!!! note "" 
-    *This article is part of the
-    [beginner tutorial on creating a totally decentralized Bitcoin price feed][intro]
-    on Ethereum with Solidity and Witnet.*
+!!! note ""
+    *This article is part of the [beginner tutorial on creating a totally
+    decentralized Bitcoin price feed][intro] on Ethereum with Solidity and
+    Witnet.*
 
 ## What is an aggregator?
 

--- a/docs/tutorials/bitcoin-price-feed/compiling.md
+++ b/docs/tutorials/bitcoin-price-feed/compiling.md
@@ -53,4 +53,5 @@ Now the next step is pretty straightforward:
 
 [discord]: https://discord.gg/X4uurfP
 [migrations]: /tutorials/bitcoin-price-feed/migrations
+[intro]: /tutorials/bitcoin-price-feed/introduction
 [next]: /tutorials/bitcoin-price-feed/contract

--- a/docs/tutorials/bitcoin-price-feed/compiling.md
+++ b/docs/tutorials/bitcoin-price-feed/compiling.md
@@ -1,8 +1,9 @@
 # 5. Compile the request
 
 !!! note ""
-    *This article is part of the [beginner tutorial on creating a totally decentralized Bitcoin price feed][intro]
-    on Ethereum with Solidity and Witnet.*
+    *This article is part of the [beginner tutorial on creating a totally
+    decentralized Bitcoin price feed][intro] on Ethereum with Solidity and
+    Witnet.*
 
 Compiling the request could not be easier:
 

--- a/docs/tutorials/bitcoin-price-feed/contract.md
+++ b/docs/tutorials/bitcoin-price-feed/contract.md
@@ -1,8 +1,9 @@
 # 6. Write your consumer contract that will handle price feed updates
 
 !!! note ""
-    *This article is part of the [beginner tutorial on creating a totally decentralized Bitcoin price feed][intro]
-    on Ethereum with Solidity and Witnet.*
+    *This article is part of the [beginner tutorial on creating a totally
+    decentralized Bitcoin price feed][intro] on Ethereum with Solidity and
+    Witnet.*
 
 ## Plan the contract
 

--- a/docs/tutorials/bitcoin-price-feed/create-project.md
+++ b/docs/tutorials/bitcoin-price-feed/create-project.md
@@ -1,9 +1,9 @@
 # 1. Create a new Witnet-enabled project
 
 !!! note ""
-    *This article is part of the
-    [beginner tutorial on creating a totally decentralized Bitcoin price feed][intro]
-    on Ethereum with Solidity and Witnet.*
+    *This article is part of the [beginner tutorial on creating a totally
+    decentralized Bitcoin price feed][intro] on Ethereum with Solidity and
+    Witnet.*
 
 ## Using the Witnet Truffle Box
 

--- a/docs/tutorials/bitcoin-price-feed/fine-tuning.md
+++ b/docs/tutorials/bitcoin-price-feed/fine-tuning.md
@@ -1,8 +1,9 @@
 # 4. Put everything together and fine-tune the Witnet request
 
 !!! note ""
-    *This article is part of the [beginner tutorial on creating a totally decentralized Bitcoin price feed][intro]
-    on Ethereum with Solidity and Witnet.*
+    *This article is part of the [beginner tutorial on creating a totally
+    decentralized Bitcoin price feed][intro] on Ethereum with Solidity and
+    Witnet.*
 
 ## Put everything together
 

--- a/docs/tutorials/bitcoin-price-feed/sources.md
+++ b/docs/tutorials/bitcoin-price-feed/sources.md
@@ -1,9 +1,9 @@
 # 2. Choose and add data sources for the price feed
 
 !!! note ""
-    *This article is part of the
-    [beginner tutorial on creating a totally decentralized Bitcoin price feed][intro]
-    on Ethereum with Solidity and Witnet.*
+    *This article is part of the [beginner tutorial on creating a totally
+    decentralized Bitcoin price feed][intro] on Ethereum with Solidity and
+    Witnet.*
 
 ## A quick intro on Witnet data sources
 


### PR DESCRIPTION
Due to missing link on compile page of tutorial it was displayed as plain text

![image](https://user-images.githubusercontent.com/1465430/78991794-0f1b7a00-7b3a-11ea-886a-d73221da4f41.png)

I also unified formatting per all tutorial pages for those intro tips