### PR TITLE
docs: add initial REAME with build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# [Witnet documentation]
+*Repository for Witnet project documentation website*
+
+## Run locally
+```console
+pip3 install -r requirements.txt
+
+mkdocs serve
+```
+
+[Witnet documentation]: https://docs.witnet.io


### PR DESCRIPTION
Adding missing instructions how to run documentation website locally