### PR TITLE
fix: update path to fetch latest genesis_block

### DIFF
--- a/docs/developer/from-source.md
+++ b/docs/developer/from-source.md
@@ -30,7 +30,7 @@ cd witnet-rust
 ## Get the latest genesis_block.json
 
 ```console
-curl https://raw.githubusercontent.com/witnet/genesis_block/latest/genesis_block.json -o genesis_block.json
+curl https://raw.githubusercontent.com/witnet/genesis_block/master/latest/genesis_block.json -o genesis_block.json
 ```
 
 ## Compile and run with `cargo`


### PR DESCRIPTION
There was a comment in telegram group related to incorrect iink.
@aesedepece replied with a correct one.
This pull request updates it.