### PR TITLE
docs: remove testnet warning

### DIFF
--- a/theme/partials/toc.html
+++ b/theme/partials/toc.html
@@ -69,9 +69,4 @@
         {% endif %}
     </ul>
     {% endif %}
-    <aside class="disclaimer">
-        <p>The Witnet protocol and related software are work in progress.</p>
-        <p>The current version is a beta stage and it may not be fully secure, as the incentives outlined in the protocol are not present in the testnet.</p>
-        <p>Check <a href="https://github.com/witnet/witnet-rust/issues" target="_blank">this list of issues</a> for more details. Make sure to understand all risks before installing the software.</p>
-    </aside>
 </nav>


### PR DESCRIPTION
- Remove warning from main page:

![image](https://user-images.githubusercontent.com/24905681/109292800-356a0700-782b-11eb-82c4-322d6046b756.png)



