### PR TITLE
Update master key import steps

### DIFF
--- a/node-operators/next-steps.md
+++ b/node-operators/next-steps.md
@@ -227,6 +227,8 @@ mkdir -p ~/.witnet/config
 
 nano ~/.witnet/config/master.key 
 
+chmod 777 ~/.witnet/config
+
 # Now enter your master key into the file editor, 
 # save with Ctrl+O and exit with Ctrl+X
 docker run -d \


### PR DESCRIPTION
Without relaxing the permissions on the config dir at creation, the witnet client cannot reach the to-be-imported master key and crashes on start up.